### PR TITLE
add reparameterized property to distributions

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -6,6 +6,7 @@ from torch.distributions import Bernoulli, Categorical, Normal
 
 
 class TestDistributions(TestCase):
+
     def _gradcheck_log_prob(self, dist_ctor, ctor_params):
         # performs gradient checks on log_prob
         distribution = dist_ctor(*ctor_params)
@@ -76,10 +77,17 @@ class TestDistributions(TestCase):
         self.assertEqual(Normal(0.2, .6).sample_n(1).size(), (1, 1))
         self.assertEqual(Normal(-0.7, 50.0).sample_n(1).size(), (1, 1))
 
+        self.assertEqual(Normal(mean, std, True).sample().size(), (5, 5))
+        self.assertEqual(Normal(mean, std, True).sample_n(7).size(), (7, 5, 5))
+        self.assertEqual(Normal(mean_1d, std_1d, True).sample_n(1).size(), (1, 1))
+        self.assertEqual(Normal(mean_1d, std_1d, True).sample().size(), (1,))
+        self.assertEqual(Normal(0.2, .6, True).sample_n(1).size(), (1, 1))
+        self.assertEqual(Normal(-0.7, 50.0, True).sample_n(1).size(), (1, 1))
+
         self._gradcheck_log_prob(Normal, (mean, std))
         self._gradcheck_log_prob(Normal, (mean, 1.0))
         self._gradcheck_log_prob(Normal, (0.0, std))
-
+        
         def ref_log_prob(idx, x, log_prob):
             m = mean.data.view(-1)[idx]
             s = std.data.view(-1)[idx]

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -33,6 +33,10 @@ class TestDistributions(TestCase):
         self.assertEqual(Bernoulli(r).sample_n(8).size(), (8, 1))
         self.assertEqual(Bernoulli(r).sample().size(), (1,))
         self._gradcheck_log_prob(Bernoulli, (p,))
+        
+        def call_sample_require_grad():
+            return Bernoulli(r).sample(requires_grad=True)
+        self.assertRaises(NotImplementedError, call_sample_require_grad)
 
         def ref_log_prob(idx, val, log_prob):
             prob = p.data[idx]
@@ -50,6 +54,11 @@ class TestDistributions(TestCase):
         # TODO: this should return a 0-dim tensor once we have Scalar support
         self.assertEqual(Categorical(p).sample().size(), (1,))
         self.assertEqual(Categorical(p).sample_n(1).size(), (1, 1))
+        
+        def call_sample_require_grad():
+            return Categorical(p).sample(requires_grad=True)
+        self.assertRaises(NotImplementedError, call_sample_require_grad)
+        
         self._gradcheck_log_prob(Categorical, (p,))
 
     def test_multinomial_2d(self):
@@ -77,12 +86,12 @@ class TestDistributions(TestCase):
         self.assertEqual(Normal(0.2, .6).sample_n(1).size(), (1, 1))
         self.assertEqual(Normal(-0.7, 50.0).sample_n(1).size(), (1, 1))
 
-        self.assertEqual(Normal(mean, std, True).sample().size(), (5, 5))
-        self.assertEqual(Normal(mean, std, True).sample_n(7).size(), (7, 5, 5))
-        self.assertEqual(Normal(mean_1d, std_1d, True).sample_n(1).size(), (1, 1))
-        self.assertEqual(Normal(mean_1d, std_1d, True).sample().size(), (1,))
-        self.assertEqual(Normal(0.2, .6, True).sample_n(1).size(), (1, 1))
-        self.assertEqual(Normal(-0.7, 50.0, True).sample_n(1).size(), (1, 1))
+        self.assertEqual(Normal(mean, std).sample(requires_grad=True).size(), (5, 5))
+        self.assertEqual(Normal(mean, std).sample_n(7,requires_grad=True).size(), (7, 5, 5))
+        self.assertEqual(Normal(mean_1d, std_1d).sample_n(1,requires_grad=True).size(), (1, 1))
+        self.assertEqual(Normal(mean_1d, std_1d,).sample(requires_grad=True).size(), (1,))
+        self.assertEqual(Normal(0.2, .6,).sample_n(1,requires_grad=True).size(), (1, 1))
+        self.assertEqual(Normal(-0.7, 50.0,).sample_n(1,requires_grad=True).size(), (1, 1))
 
         self._gradcheck_log_prob(Normal, (mean, std))
         self._gradcheck_log_prob(Normal, (mean, 1.0))

--- a/torch/distributions.py
+++ b/torch/distributions.py
@@ -41,8 +41,8 @@ class Distribution(object):
     r"""
     Distribution is the abstract base class for probability distributions.
     """
-    def __init__(self, reparametrized = False):
-        self.reparametrized = reparametrized
+    def __init__(self, reparameterized = False):
+        self.reparameterized = reparameterized
     
     def sample(self):
         """
@@ -89,8 +89,8 @@ class Bernoulli(Distribution):
 
     def __init__(self, probs):
         self.probs = probs
-        # Bernoulli can't be reparametrized
-        super(Bernoulli, self).__init__(reparametrized=False)
+        # Bernoulli can't be reparameterized
+        super(Bernoulli, self).__init__(reparameterized=False)
 
     def sample(self):
         return torch.bernoulli(self.probs)
@@ -138,8 +138,8 @@ class Categorical(Distribution):
             # TODO: treat higher dimensions as part of the batch
             raise ValueError("probs must be 1D or 2D")
         self.probs = probs
-        # Categorical can't be reparametrized
-        super(Categorical, self).__init__(reparametrized=False)
+        # Categorical can't be reparameterized
+        super(Categorical, self).__init__(reparameterized=False)
 
     def sample(self):
         return torch.multinomial(self.probs, 1, True).squeeze(-1)
@@ -174,16 +174,16 @@ class Normal(Distribution):
     Args:
         mean (float or Tensor or Variable): mean of the distribution
         std (float or Tensor or Variable): standard deviation of the distribution
-        reparametrized (bool): whether to use reparametrization trick
+        reparameterized (bool): whether to use reparameterization trick
     """
 
-    def __init__(self, mean, std, reparametrized = False):
+    def __init__(self, mean, std, reparameterized = False):
         self.mean = mean
         self.std = std
-        super(Normal, self).__init__(reparametrized=reparametrized)
+        super(Normal, self).__init__(reparameterized=reparameterized)
 
     def sample(self):
-        if self.reparametrized:
+        if self.reparameterized:
             eps = torch.normal(torch.zeros_like(self.mean), torch.ones_like(self.std))
             return self.mean + self.std * eps
         else:    
@@ -198,7 +198,7 @@ class Normal(Distribution):
                 return v.expand(n, *v.size())
         expanded_mean = expand(self.mean)
         expanded_std = expand(self.std)
-        if self.reparametrized:
+        if self.reparameterized:
             eps = torch.normal(torch.zeros_like(expanded_mean), torch.ones_like(expanded_std))
             return expanded_mean + expanded_std * eps
         else:

--- a/torch/distributions.py
+++ b/torch/distributions.py
@@ -43,25 +43,6 @@ class Distribution(object):
     """
     reparameterized = False
 
-    @staticmethod
-    def non_reparameterized_sampler(func):
-        """
-        This is a simple decorator that wraps all samplers of non-reparameterized
-        distributions. It adds requires_grad argument, throws error if requires_grad
-        is True, else it calls the function it is wrapping. 
-        NOTE: With this decorator, requires_grad must be a named argument.
-        (Distribution.sample(True) will not work)
-        """
-        def wrapper(*args, **kwargs):
-            if 'requires_grad' not in kwargs:
-                kwargs['requires_grad'] = False
-            if not kwargs['requires_grad']:
-                del kwargs['requires_grad']
-                return func(*args, **kwargs)
-            else:
-                raise NotImplementedError("Can't sample from non-reparameterized {} with requires_grad=True".format(args[0].__class__.__name__))
-        return wrapper
-
     def sample(self, requires_grad=False):
         """
         Generates a single sample or single batch of samples if the distribution
@@ -108,12 +89,14 @@ class Bernoulli(Distribution):
     def __init__(self, probs):
         self.probs = probs
 
-    @Distribution.non_reparameterized_sampler
-    def sample(self):
+    def sample(self, requires_grad=False):
+        if requires_grad:
+            raise NotImplementedError("Can't sample from non-reparameterized Bernoulli with requires_grad=True")
         return torch.bernoulli(self.probs)
 
-    @Distribution.non_reparameterized_sampler
-    def sample_n(self, n):
+    def sample_n(self, n, requires_grad=False):
+        if requires_grad:
+            raise NotImplementedError("Can't sample from non-reparameterized Bernoulli with requires_grad=True")
         return torch.bernoulli(self.probs.expand(n, *self.probs.size()))
 
     def log_prob(self, value):
@@ -157,12 +140,14 @@ class Categorical(Distribution):
             raise ValueError("probs must be 1D or 2D")
         self.probs = probs
 
-    @Distribution.non_reparameterized_sampler
-    def sample(self):
+    def sample(self, requires_grad=False):
+        if requires_grad:
+            raise NotImplementedError("Can't sample from non-reparameterized Categorical with requires_grad=True")
         return torch.multinomial(self.probs, 1, True).squeeze(-1)
 
-    @Distribution.non_reparameterized_sampler
-    def sample_n(self, n):
+    def sample_n(self, n, requires_grad=False):
+        if requires_grad:
+            raise NotImplementedError("Can't sample from non-reparameterized Categorical with requires_grad=True")
         if n == 1:
             return self.sample().expand(1, 1)
         else:


### PR DESCRIPTION
add `.reparametrized` property to distributions
- add `__init__` function to distributions (currently only assigns `.reparametrized` property)
- add tests to check outputs of `Normal.sample` when reparametrized
- addresses https://github.com/probtorch/pytorch/issues/7