### PR TITLE
Bernoulli py2.7 fix

### DIFF
--- a/torch/distributions.py
+++ b/torch/distributions.py
@@ -133,7 +133,7 @@ class Bernoulli(Distribution):
                                           probs.data.type())
 
     def sample(self, *sizes):
-        sizes = list(sizes) + list(self.probs.size())
+        sizes = expanded_size(sizes, self.probs.size())
         return torch.bernoulli(self.probs.expand(*sizes))
 
     def log_prob(self, value):

--- a/torch/distributions.py
+++ b/torch/distributions.py
@@ -133,7 +133,8 @@ class Bernoulli(Distribution):
                                           probs.data.type())
 
     def sample(self, *sizes):
-        return torch.bernoulli(self.probs.expand(*sizes, *self.probs.size()))
+        sizes = list(sizes) + list(self.probs.size())
+        return torch.bernoulli(self.probs.expand(*sizes))
 
     def log_prob(self, value):
         # compute the log probabilities for 0 and 1


### PR DESCRIPTION
This "double-splat" notation doesn't seem to work under python 2.7 (it causes a parse error when reading the file; see #23). I saw there was already an `expanded_size` helper function — using that instead.