### PR TITLE
Implement Reparameterized version of Gamma

### DIFF
--- a/aten/src/TH/THRandom.c
+++ b/aten/src/TH/THRandom.c
@@ -305,6 +305,42 @@ double THRandom_standard_gamma(THGenerator *_generator, double alpha) {
   }
 }
 
+double THRandom_standard_gamma_grad(double x, double alpha) {
+    // Use asymptotic approximation for small x:
+    // pdf(x) = x^(alpha - 1) / Gamma(alpha)
+    if (x < 0.001) {
+        const double eps = alpha * 1e-2;
+        const double digamma_alpha = (lgamma(alpha + eps) - lgamma(alpha - eps)) / (2.0 * eps);
+        const double result = -x / alpha * (log(x) - 1 / alpha - digamma_alpha);
+        return isnan(result) ? 0.0 : result;
+    }
+
+    // Use an asymptotic Normal approximation for large alpha:
+    // x ~ Normal(mean=alpha, std=sqrt(alpha))
+    if (alpha > 30.0) {
+        return sqrt(x / alpha);
+    }
+
+    // Use a bivariate rational approximation to the reparameterized gradient.
+    const double u = log(x / alpha);
+    const double v = log(alpha);
+    static const double coef_uv[3][8] = {
+      {0.1606678, -0.11522799, 0.033979559, -0.0036550799,
+       1.0, 0.20731141, 0.067549705, 0.0022689283},
+      {0.50972793, 0.088434194, 0.039248477, 0.00078142115,
+       0.0017221762, 0.0087442751, -0.0028899172, -0.00025318191},
+      {-0.044541408, -0.0023919443, -0.0036231108, -0.00025103067,
+       0.002784394, 0.00028505613, 1.3238159e-05, -8.6837586e-07},
+    };
+    double coef_v[8];
+    for (int i = 0; i < 8; ++ i) {
+        coef_v[i] = coef_uv[0][i] + u * (coef_uv[1][i] + u * coef_uv[2][i]);
+    }
+    const double p = coef_v[0] + v * (coef_v[1] + v * (coef_v[2] + v * coef_v[3]));
+    const double q = coef_v[4] + v * (coef_v[5] + v * (coef_v[6] + v * coef_v[7]));
+    return exp(p / q);
+}
+
 double THRandom_cauchy(THGenerator *_generator, double median, double sigma)
 {
   return(median + sigma * tan(M_PI*(uniform_double(_generator)-0.5)));

--- a/aten/src/TH/THRandom.h
+++ b/aten/src/TH/THRandom.h
@@ -65,11 +65,16 @@ TH_API double THRandom_normal(THGenerator *_generator, double mean, double stdv)
 */
 TH_API double THRandom_exponential(THGenerator *_generator, double lambda);
 
-/** Generates a random number from a standard Gamma distribution.
+/** Generates a random number from the standard Gamma distribution.
     The Gamma density is proportional to $x^{alpha-1} exp(-x)$
     The shape parameter alpha (a.k.a. k) is a positive real number.
 */
 TH_API double THRandom_standard_gamma(THGenerator *_generator, double alpha);
+
+/** Computes a reparameterized gradient of a sample from a standard Gamma
+    distribution wrt the shape parameter alpha.
+*/
+TH_API double THRandom_standard_gamma_grad(double x, double alpha);
 
 /** Returns a random number from a Cauchy distribution.
     The Cauchy density is $p(x) = sigma/(pi*(sigma^2 + (x-median)^2))$

--- a/aten/src/TH/THRandom.h
+++ b/aten/src/TH/THRandom.h
@@ -65,7 +65,7 @@ TH_API double THRandom_normal(THGenerator *_generator, double mean, double stdv)
 */
 TH_API double THRandom_exponential(THGenerator *_generator, double lambda);
 
-/** Generates a random number from the standard Gamma distribution.
+/** Generates a random number from a standard Gamma distribution.
     The Gamma density is proportional to $x^{alpha-1} exp(-x)$
     The shape parameter alpha (a.k.a. k) is a positive real number.
 */

--- a/aten/src/TH/generic/THTensorRandom.c
+++ b/aten/src/TH/generic/THTensorRandom.c
@@ -111,7 +111,17 @@ void THTensor_(exponential)(THTensor *self, THGenerator *_generator, double lamb
 void THTensor_(standard_gamma)(THTensor *self, THGenerator *gen, THTensor *alpha)
 {
   THTensor_(resizeAs)(self, alpha);
-  TH_TENSOR_APPLY2(real, self, real, alpha, *self_data = THRandom_standard_gamma(gen, *alpha_data););
+  TH_TENSOR_APPLY2(real, self, real, alpha, {
+    *self_data = THRandom_standard_gamma(gen, *alpha_data);
+  });
+}
+
+void THTensor_(standard_gamma_grad)(THTensor *self, THTensor *x, THTensor *alpha)
+{
+  THTensor_(resizeAs)(self, x);
+  TH_TENSOR_APPLY3(real, self, real, x, real, alpha, {
+    *self_data = (real)THRandom_standard_gamma_grad(*x_data, *alpha_data);
+  });
 }
 
 void THTensor_(cauchy)(THTensor *self, THGenerator *_generator, double median, double sigma)

--- a/aten/src/TH/generic/THTensorRandom.h
+++ b/aten/src/TH/generic/THTensorRandom.h
@@ -18,6 +18,7 @@ TH_API void THTensor_(normal_stddevs)(THTensor *self, THGenerator *gen, double m
 TH_API void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, THTensor *means, THTensor *stddevs);
 TH_API void THTensor_(exponential)(THTensor *self, THGenerator *_generator, double lambda);
 TH_API void THTensor_(standard_gamma)(THTensor *self, THGenerator *_generator, THTensor *alpha);
+TH_API void THTensor_(standard_gamma_grad)(THTensor *self, THTensor *x, THTensor *alpha);
 TH_API void THTensor_(cauchy)(THTensor *self, THGenerator *_generator, double median, double sigma);
 TH_API void THTensor_(logNormal)(THTensor *self, THGenerator *_generator, double mean, double stdv);
 TH_API void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTensor *prob_dist, int n_sample, int with_replacement);

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -43,7 +43,10 @@ class TestDistributions(TestCase):
     def _check_sampler_sampler(self, torch_dist, ref_dist, message,
                                num_samples=10000, failure_rate=1e-3):
         # Checks that the .sample() method matches a reference function.
-        torch_samples = torch_dist.sample_n(num_samples).squeeze().cpu().numpy()
+        torch_samples = torch_dist.sample_n(num_samples).squeeze()
+        if isinstance(torch_samples, Variable):
+            torch_samples = torch_samples.data
+        torch_samples = torch_samples.cpu().numpy()
         ref_samples = ref_dist.rvs(num_samples)
         samples = [(x, +1) for x in torch_samples] + [(x, -1) for x in ref_samples]
         samples.sort()
@@ -160,8 +163,37 @@ class TestDistributions(TestCase):
         self._set_rng_seed()
         for alpha, beta in product([0.1, 1.0, 5.0], [0.1, 1.0, 10.0]):
             self._check_sampler_sampler(Gamma(alpha, beta),
-                                        scipy.stats.gamma(alpha, scale=1 / beta),
+                                        scipy.stats.gamma(alpha, scale=1.0 / beta),
                                         'Gamma(alpha={}, beta={})'.format(alpha, beta))
+
+    # This is a randomized test.
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    def test_gamma_sample_grad(self):
+        self._set_rng_seed()
+        num_samples = 100
+        for alpha in [1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3, 1e4]:
+            alphas = Variable(torch.Tensor([alpha] * num_samples), requires_grad=True)
+            betas = Variable(torch.ones(num_samples))
+            x = Gamma(alphas, betas).sample()
+            x.sum().backward()
+            x, ind = x.data.sort()
+            x = x.numpy()
+            actual_grad = alphas.grad.data[ind].numpy()
+            # Compare with expected gradient dx/dalpha along constant cdf(x,alpha).
+            cdf = scipy.stats.gamma.cdf
+            pdf = scipy.stats.gamma.pdf
+            eps = 0.02 * alpha if alpha < 100 else 0.02 * alpha ** 0.5
+            cdf_alpha = (cdf(x, alpha + eps) - cdf(x, alpha - eps)) / (2 * eps)
+            cdf_x = pdf(x, alpha)
+            expected_grad = -cdf_alpha / cdf_x
+            rel_error = np.abs(actual_grad - expected_grad) / (expected_grad + 1e-100)
+            self.assertLess(np.max(rel_error), 0.01,
+                            '\n'.join(['Bad gradients for Gamma({}, 1)'.format(alpha),
+                                       'x {}'.format(x),
+                                       'expected {}'.format(expected_grad),
+                                       'actual {}'.format(actual_grad),
+                                       'rel error {}'.format(rel_error),
+                                       'max error {}'.format(rel_error.max())]))
 
 
 if __name__ == '__main__':

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -304,6 +304,11 @@ class Variable(_C._VariableBase):
     def bernoulli(self):
         return Variable(torch.bernoulli(self.data))
 
+    def standard_gamma(self, grad=None):
+        if grad is None:
+            return Variable(torch.standard_gamma(self.data))
+        return Variable(torch.standard_gamma(self.data, grad), requires_grad=self.requires_grad)
+
     def __rsub__(self, other):
         return -self + other
 
@@ -357,6 +362,7 @@ class Variable(_C._VariableBase):
             if isinstance(std, Variable):
                 std = std.data
             return Variable(torch.normal(means, std))
+
 
 for method in dir(Variable):
     # This will also wrap some methods that normally aren't part of the

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -363,7 +363,6 @@ class Variable(_C._VariableBase):
                 std = std.data
             return Variable(torch.normal(means, std))
 
-
 for method in dir(Variable):
     # This will also wrap some methods that normally aren't part of the
     # functional interface, but we don't care, as they won't ever be used

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -344,6 +344,7 @@ IMPLEMENT_STATELESS(bmm)
 IMPLEMENT_STATELESS(multinomial)
 IMPLEMENT_STATELESS(normal)
 IMPLEMENT_STATELESS(standard_gamma)
+IMPLEMENT_STATELESS(standard_gamma_grad)
 IMPLEMENT_STATELESS(bernoulli)
 IMPLEMENT_STATELESS(range)
 IMPLEMENT_STATELESS(arange)
@@ -701,6 +702,7 @@ static PyMethodDef TorchMethods[] = {
   {"multinomial",     (PyCFunction)THPModule_multinomial,       METH_VARARGS | METH_KEYWORDS, NULL},
   {"normal",          (PyCFunction)THPModule_normal,            METH_VARARGS | METH_KEYWORDS, NULL},
   {"_standard_gamma",  (PyCFunction)THPModule_standard_gamma,    METH_VARARGS | METH_KEYWORDS, NULL},
+  {"_standard_gamma_grad", (PyCFunction)THPModule_standard_gamma_grad, METH_VARARGS | METH_KEYWORDS, NULL},
   {"bernoulli",       (PyCFunction)THPModule_bernoulli,         METH_VARARGS | METH_KEYWORDS, NULL},
   {"rand",            (PyCFunction)THPModule_rand,              METH_VARARGS | METH_KEYWORDS, NULL},
   {"randn",           (PyCFunction)THPModule_randn,             METH_VARARGS | METH_KEYWORDS, NULL},

--- a/torch/csrc/generic/methods/TensorRandom.cwrap
+++ b/torch/csrc/generic/methods/TensorRandom.cwrap
@@ -231,6 +231,24 @@
 ]]
 
 [[
+  name: standard_gamma_grad
+  types:
+    - floating_point
+  backends:
+    - CPU
+  return: argument 0
+  variants:
+    - function
+  options:
+    - cname: standard_gamma_grad
+      arguments:
+        - arg: THTensor* output
+          output: True
+        - THTensor* x
+        - THTensor* alpha
+]]
+
+[[
   name: rand
   types:
     - floating_point

--- a/torch/distributions.py
+++ b/torch/distributions.py
@@ -32,8 +32,8 @@ policy, the code for implementing REINFORCE would be as follows::
 import math
 from numbers import Number
 import torch
-from torch.autograd import Variable
-
+from torch.autograd import Function, Variable
+from torch.autograd.function import once_differentiable
 
 __all__ = ['Distribution', 'Bernoulli', 'Categorical', 'Normal', 'Gamma']
 
@@ -198,10 +198,27 @@ class Normal(Distribution):
         return -((value - self.mean) ** 2) / (2 * var) - log_std - math.log(math.sqrt(2 * math.pi))
 
 
+class _StandardGamma(Function):
+    @staticmethod
+    def forward(ctx, alpha):
+        x = torch._C._standard_gamma(alpha)
+        ctx.save_for_backward(x, alpha)
+        return x
+
+    @staticmethod
+    @once_differentiable
+    def backward(ctx, grad_output):
+        x, alpha = ctx.saved_tensors
+        grad = torch._C._standard_gamma_grad(x, alpha)
+        return grad_output * grad
+
+
 def _standard_gamma(alpha):
     if not isinstance(alpha, Variable):
         return torch._C._standard_gamma(alpha)
-    return Variable(torch._C._standard_gamma(alpha.data))
+    if not alpha.requires_grad:
+        return Variable(torch._C._standard_gamma(alpha.data))
+    return _StandardGamma.apply(alpha)
 
 
 class Gamma(Distribution):
@@ -219,6 +236,7 @@ class Gamma(Distribution):
         alpha (float or Tensor or Variable): shape parameter of the distribution
         beta (float or Tensor or Variable): rate = 1 / scale of the distribution
     """
+    reparameterized = True
 
     def __init__(self, alpha, beta):
         # TODO handle (Variable, Number) cases


### PR DESCRIPTION
Fixes #25 

**DO NOT MERGE.** This PR will be moved to the pytorch org after https://github.com/pytorch/pytorch/pull/3841 is merged.

This implements reparameterized gradient for `distributions.Gamma`. The gradient is implemented by directly approximating the reparameterized gradient function `dx/dalpha` following [Knowles (2015)](https://arxiv.org/pdf/1509.01631.pdf). The approximation is accurate to within 1% relative error for a wide range of alphas.

## Derivation

Note that if `x ~ Gamma(alpha, beta)` then `x / beta ~ Gamma(alpha, 1)`. Since division is already implemented in PyTorch, we can thus reduce our problem to computing a reparameterized gradient of a standard gamma `x ~ Gamma(alpha) = Gamma(alpha, 1)` wrt `alpha`.

This PR implements a function `standard_gamma_grad(x, alpha)` that directly approximates the reparameterized gradient defined (for any continuous univariate distribution) as
```
                d/dalpha cdf(x; alpha)     d/dalpha cdf(x; alpha)
dx / dalpha = - ---------------------- = - ----------------------
                  d/dx cdf(x; alpha)           pdf(x; alpha)
```
This definition is used in the unit tests in `tests/test_distributions.py`, which compute `d/dalpha cdf(x;alpha)` via finite difference of the `scipy.stats.gamma.cdf()` function.

The approximation is split into three regions:
- For `x < 0.001` we differentiate the power-law approximation from Knowles (2015)
  ```
  cdf(x; alpha)  \approx  x**alpha / (alpha * Gamma(alpha))
  standard_gamma_grad(x, alpha) = -x/alpha * (log(x) - 1/alpha - digamma(alpha))
  ```
  Until `digamma()` is implemented in PyTorch, we use a finite difference of `lgamma()`.
- For `alpha > 30` we use the approximation
  ```
  standard_gamma_grad(x, alpha) = sqrt(x/alpha)
  ```
- For intermediate x,alpha we use a rational function approximation
   ```
   standard_gamma_grad(x, alpha) = exp(PQ(log(x / alpha), log(alpha)))
   ```
   where `PQ(u,v)` is a rational function of order 2 in u and 3 in v. This was trained using least squares minimizing squared relative error on ~20000 samples drawn from
  ```
  alpha ~ log_uniform(1e-5, 1e2)
  x ~ Gamma(alpha)
  ```

For complete derivation, see this [Jupyter Notebook](https://github.com/fritzo/notebooks/blob/master/gamma-reparameterized.ipynb).