### PR TITLE
One hot categorical

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -48,3 +48,15 @@ Probability distributions - torch.distributions
 
 .. autoclass:: Normal
     :members:
+
+:hidden:`OneHotCategorical`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: OneHotCategorical
+    :members:
+
+:hidden:`Uniform`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: Uniform
+    :members:

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -753,6 +753,7 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(dist._event_shape, torch.Size((2,)))
         self.assertEqual(dist.sample().size(), torch.Size((3, 2)))
         self.assertEqual(dist.sample((3, 2)).size(), torch.Size((3, 2, 3, 2)))
+        self.assertEqual(dist.log_prob(self.tensor_sample_1).size(), torch.Size((3,)))
         self.assertRaises(ValueError, dist.log_prob, self.tensor_sample_2)
         self.assertEqual(dist.log_prob(dist.enumerate_support()).size(), torch.Size((2, 3)))
 

--- a/torch/distributions/__init__.py
+++ b/torch/distributions/__init__.py
@@ -35,10 +35,23 @@ from .beta import Beta
 from .categorical import Categorical
 from .dirichlet import Dirichlet
 from .distribution import Distribution
-from .gamma import Gamma
-from .normal import Normal
 from .exponential import Exponential
+from .gamma import Gamma
 from .laplace import Laplace
+from .normal import Normal
+from .one_hot_categorical import OneHotCategorical
+from .uniform import Uniform
 
-
-__all__ = ['Distribution', 'Bernoulli', 'Beta', 'Categorical', 'Dirichlet', 'Gamma', 'Normal', 'Exponential', 'Laplace']
+__all__ = [
+    'Bernoulli',
+    'Beta',
+    'Categorical',
+    'Dirichlet',
+    'Distribution',
+    'Exponential',
+    'Gamma',
+    'Laplace',
+    'Normal',
+    'OneHotCategorical',
+    'Uniform',
+]

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -15,6 +15,20 @@ class Distribution(object):
         self._batch_shape = batch_shape
         self._event_shape = event_shape
 
+    @property
+    def batch_shape(self):
+        """
+        Returns the shape over which parameters are batched.
+        """
+        return self._batch_shape
+
+    @property
+    def event_shape(self):
+        """
+        Returns the shape of a single sample (without batching).
+        """
+        return self._event_shape
+
     def sample(self, sample_shape=torch.Size()):
         """
         Generates a sample_shape shaped sample or sample_shape shaped batch of
@@ -74,7 +88,7 @@ class Distribution(object):
         """
         raise NotImplementedError
 
-    def _extended_shape(self, sample_shape=()):
+    def _extended_shape(self, sample_shape=torch.Size()):
         """
         Returns the size of the sample returned by the distribution, given
         a `sample_shape`. Note, that the batch and event shapes of a distribution
@@ -84,7 +98,7 @@ class Distribution(object):
         Args:
             sample_shape (torch.Size): the size of the sample to be drawn.
         """
-        shape = sample_shape + self._batch_shape + self._event_shape
+        shape = torch.Size(sample_shape + self._batch_shape + self._event_shape)
         if not shape:
             shape = torch.Size((1,))
         return shape

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -36,7 +36,7 @@ class OneHotCategorical(Distribution):
     def sample(self, sample_shape=torch.Size()):
         sample_shape = torch.Size(sample_shape)
         probs = self._categorical.probs
-        one_hot = probs.new(sample_shape + probs.size()).zero_()
+        one_hot = probs.new(self._extended_shape(sample_shape)).zero_()
         indices = self._categorical.sample(sample_shape)
         if indices.dim() < one_hot.dim():
             indices = indices.unsqueeze(-1)
@@ -51,7 +51,7 @@ class OneHotCategorical(Distribution):
 
     def enumerate_support(self):
         probs = self._categorical.probs
-        n = probs.shape[-1]
+        n = self.event_shape[0]
         if isinstance(probs, Variable):
             values = Variable(torch.eye(n, out=probs.data.new(n, n)))
         else:

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -1,0 +1,60 @@
+import torch
+from torch.autograd import Variable
+from torch.distributions.distribution import Distribution
+from torch.distributions.categorical import Categorical
+
+
+class OneHotCategorical(Distribution):
+    r"""
+    Creates a one-hot categorical distribution parameterized by `probs`.
+
+    Samples are one-hot coded vectors of size probs.size(-1).
+
+    See also: :func:`torch.distributions.Categorical`
+
+    Example::
+
+        >>> m = OneHotCategorical(torch.Tensor([ 0.25, 0.25, 0.25, 0.25 ]))
+        >>> m.sample()  # equal probability of 0, 1, 2, 3
+         0
+         0
+         1
+         0
+        [torch.FloatTensor of size 4]
+
+    Args:
+        probs (Tensor or Variable): event probabilities
+    """
+    has_enumerate_support = True
+
+    def __init__(self, probs):
+        self._categorical = Categorical(probs)
+        batch_shape = probs.size()[:-1]
+        event_shape = probs.size()[-1:]
+        super(OneHotCategorical, self).__init__(batch_shape, event_shape)
+
+    def sample(self, sample_shape=torch.Size()):
+        sample_shape = torch.Size(sample_shape)
+        probs = self._categorical.probs
+        one_hot = probs.new(sample_shape + probs.size()).zero_()
+        indices = self._categorical.sample(sample_shape)
+        if indices.dim() < one_hot.dim():
+            indices = indices.unsqueeze(-1)
+        return one_hot.scatter_(-1, indices, 1)
+
+    def log_prob(self, value):
+        indices = value.max(-1)[1]
+        return self._categorical.log_prob(indices)
+
+    def entropy(self):
+        return self._categorical.entropy()
+
+    def enumerate_support(self):
+        probs = self._categorical.probs
+        n = probs.shape[-1]
+        if isinstance(probs, Variable):
+            values = Variable(torch.eye(n, out=probs.data.new(n, n)))
+        else:
+            values = torch.eye(n, out=probs.new(n, n))
+        values = values.view((n,) + (1,) * len(self.batch_shape) + (n,))
+        return values.expand((n,) + self.batch_shape + (n,))


### PR DESCRIPTION
Fixes #5 
Fixes #8 
Fixes https://github.com/pytorch/pytorch/issues/4353

This implements a `OneHotCategorial` distribution as a thin wrapper around `Categorical`. This is the most well-tested multivariate distribution (`Dirichlet` is the only other multivariate distribution and that is mostly tested by the `Beta` special case). I've fixed a number of issues with `test_distributions.py` to allow easier testing of multivariate distributions.

This also adds `.batch_shape` and `.event_shape` properties .

Finally this sets random number seeds in `setUp` methods as suggested by @ezyang.