### PR TITLE
Implement transforms for distribution parameters

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -90,3 +90,47 @@ Probability distributions - torch.distributions
 
 .. autoclass:: Uniform
     :members:
+
+Constraints
+~~~~~~~~~~~~
+
+.. automodule:: torch.distributions.constraints
+.. currentmodule:: torch.distributions.constraints
+
+:hidden:`Constraint`
+-----------------------
+
+.. autoclass:: Constraint
+    :members:
+
+:hidden:`is_dependent`
+-----------------------------
+
+.. autofunction:: torch.distributions.constraints.is_dependent
+
+:hidden:`@dependent_property`
+-----------------------------
+
+.. autoclass:: torch.distributions.constraints.dependent_property
+
+Transforms
+~~~~~~~~~~~
+
+.. automodule:: torch.distributions.transforms
+.. currentmodule:: torch.distributions.transforms
+
+:hidden:`transform`
+-----------------------------
+
+.. autofunction:: torch.distributions.transforms.transform
+
+:hidden:`Transform`
+-----------------------
+
+.. autoclass:: Transform
+    :members:
+
+:hidden:`register_transform`
+-----------------------------
+
+.. autofunction:: torch.distributions.transforms.register_transform

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1143,6 +1143,22 @@ class TestConstraints(TestCase):
             good = good.expand(shape)
             self.assertTrue(lower_triangular.check(good).all())
 
+    def test_lower_triangular_transform(self):
+        t = transform(lower_triangular)
+        for shape in [(2, 2), (2, 3, 3), (2, 3, 4, 4)]:
+            shape = torch.Size(shape)
+            x = torch.Tensor(shape).normal_()
+            mask = torch.tril(x.new([1]).byte().expand(x.shape[-2:]))
+            mask = mask.view((1,) * (x.dim() - 2) + mask.shape).expand_as(x)
+            x[~mask] = 0
+            self.assertTrue(lower_triangular.check(x).all())
+            u = t.to_unconstrained(x)
+            actual = t.to_constrained(u)
+            self.assertEqual(actual, x)
+            u2 = u + u.new(u.shape).normal_()
+            x2 = t.to_constrained(u2)
+            self.assertTrue(lower_triangular.check(x2).all())
+
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -33,7 +33,7 @@ from torch.autograd import Variable, gradcheck
 from torch.distributions import (Bernoulli, Beta, Categorical, Cauchy, Chi2,
                                  Dirichlet, Exponential, Gamma, Laplace,
                                  Normal, OneHotCategorical, Pareto, Uniform)
-from torch.distributions.constraints import Constraint, is_dependent
+from torch.distributions.constraints import Constraint, is_dependent, lower_triangular
 from torch.distributions.transforms import transform
 
 TEST_NUMPY = True
@@ -1132,6 +1132,16 @@ class TestConstraints(TestCase):
                 message = '{} example {}/{} sample. expected {}, actual {}'.format(
                     Dist.__name__, i, len(params), value, actual)
                 self.assertEqual(rel_error.max(), 0, message)
+
+    def test_lower_triangular_check(self):
+        for shape in [(2, 2), (2, 3, 3), (2, 3, 4, 4)]:
+            shape = torch.Size(shape)
+            bad = torch.ones(shape)
+            self.assertFalse(lower_triangular.check(bad).any())
+            good = torch.tril(torch.ones(shape[-2:]))
+            good = good.view((1,) * (len(shape) - 2) + shape[-2:])
+            good = good.expand(shape)
+            self.assertTrue(lower_triangular.check(good).all())
 
 
 if __name__ == '__main__':

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -138,7 +138,8 @@ class _LowerTriangular(Constraint):
     Constrain to lower-triangular square matrices.
     """
     def check(self, value):
-        return (torch.tril(value) == value).min(-1).min(-1)
+        mask = torch.tril(value.new([1]).byte().expand(value.shape[-2:]))
+        return (~mask & value == 0).min(-1).min(-1)
 
 
 # Public interface.

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -139,7 +139,7 @@ class _LowerTriangular(Constraint):
     """
     def check(self, value):
         mask = torch.tril(value.new([1]).byte().expand(value.shape[-2:]))
-        return (~mask & value == 0).min(-1).min(-1)
+        return (mask | (value == 0)).min(-1)[0].min(-1)[0]
 
 
 # Public interface.

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -1,5 +1,20 @@
-import torch
+r"""
+The following constraints are implemented:
 
+- ``constraints.dependent``
+- ``constraints.boolean``
+- ``constraints.greater_than(lower_bound)``
+- ``constraints.integer_interval(lower_bound, upper_bound)``
+- ``constraints.interval(lower_bound, upper_bound)``
+- ``constraints.lower_triangular``
+- ``constraints.nonnegative_integer``
+- ``constraints.positive``
+- ``constraints.real``
+- ``constraints.simplex``
+- ``constraints.unit_interval``
+"""
+
+import torch
 
 __all__ = [
     'Constraint',
@@ -44,13 +59,22 @@ class _Dependent(Constraint):
 
 
 def is_dependent(constraint):
+    """
+    Args:
+        constraint (:class:`Constraint`): A constraint object.
+
+    Returns:
+        (bool): Whether the constrained value is dependent on other values.
+        If so, there is no simple coordinate-wise way to constrain the value.
+    """
     return isinstance(constraint, _Dependent)
 
 
-class _DependentProperty(property, _Dependent):
+class dependent_property(property, _Dependent):
     """
-    Decorator that extends @property to act like a `Dependent` constraint when
-    called on a class and act like a property when called on an object.
+    Decorator that extends :class:`property` to act like a :class:`dependent`
+    constraint when called on a class and act like a property when called on
+    an object.
 
     Example::
 
@@ -81,7 +105,7 @@ class _NonnegativeInteger(Constraint):
         return (value % 1 == 0) & (value >= 0)
 
 
-class _IntegerInterval(Constraint):
+class integer_interval(Constraint):
     """
     Constrain to an integer interval `[lower_bound, upper_bound]`.
     """
@@ -101,7 +125,7 @@ class _Real(Constraint):
         return value == value  # False for NANs.
 
 
-class _GreaterThan(Constraint):
+class greater_than(Constraint):
     """
     Constrain to a real half line `[lower_bound, inf]`.
     """
@@ -112,7 +136,7 @@ class _GreaterThan(Constraint):
         return self.lower_bound <= value
 
 
-class _Interval(Constraint):
+class interval(Constraint):
     """
     Constrain to a real interval `[lower_bound, upper_bound]`.
     """
@@ -142,16 +166,12 @@ class _LowerTriangular(Constraint):
         return (mask | (value == 0)).min(-1)[0].min(-1)[0]
 
 
-# Public interface.
+# Singleton instances for public interface.
 dependent = _Dependent()
-dependent_property = _DependentProperty
 boolean = _Boolean()
 nonnegative_integer = _NonnegativeInteger()
-integer_interval = _IntegerInterval
 real = _Real()
-positive = _GreaterThan(0)
-greater_than = _GreaterThan
-unit_interval = _Interval(0, 1)
-interval = _Interval
+positive = greater_than(0)
+unit_interval = interval(0, 1)
 simplex = _Simplex()
 lower_triangular = _LowerTriangular()

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -32,17 +32,19 @@ class Distribution(object):
     @property
     def params(self):
         """
-        Returns a dictionary from param names to `Constraint` objects that
+        Returns a dictionary from param names to
+        :class:`~torch.distributions.constraints.Constraint` objects that
         should be satisfied by each parameter of this distribution. For
-        distributions with multiple parameterization, only one complete
-        set of parameters should be specified in `.params`.
+        distributions with multiple parameterization, only one complete set of
+        parameters should be specified in `.params`.
         """
         raise NotImplementedError
 
     @property
     def support(self):
         """
-        Returns a `Constraint` object representing this distribution's support.
+        Returns a :class:`~torch.distributions.constraints.Constraint` object
+        representing this distribution's support.
         """
         raise NotImplementedError
 

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -1,0 +1,185 @@
+from __future__ import division
+
+import torch
+from torch.autograd import Variable
+from torch.distributions import constraints
+from torch.nn.functional import sigmoid, softmax
+
+__all__ = ['transform', 'register_transform', 'Transform']
+
+_TRANSFORMS = {}
+
+
+def transform(constraint):
+    """
+    Looks up a pair of transforms to- and from- unconstrained space, given
+    a constraint object. Usage::
+
+        constraint = Normal.params['scale']
+        scale = transform(constraint).to_constrained(torch.zeros(1))
+        u = transform(constraint).to_unconstrained(scale)
+    """
+    # Look up by singleton instance.
+    try:
+        return _TRANSFORMS[constraint]
+    except KeyError:
+        pass
+    # Look up by Constraint subclass.
+    try:
+        Trans = _TRANSFORMS[type(constraint)]
+    except KeyError:
+        raise NotImplementedError(
+            'Cannot transform {} constraints'.format(type(constraint).__name__))
+    return Trans(constraint)
+
+
+def register_transform(constraint):
+    """
+    Decorator to register a `Constraint` subclass or singleton object with the
+    `torch.distributions.transforms.transform()` function. Usage::
+
+        @register_transform(MyConstraintClass)
+        class MyTransform(Transform):
+            def to_unconstrained(self, x):
+                ...
+            def to_constrained(self, u):
+                ...
+
+    Args:
+        constraint (Constraint subclass or instance): Either a specific
+            constraint or a class of constraints.
+    """
+
+    def decorator(transform_class):
+        if isinstance(constraint, constraints.Constraint):
+            # Register singleton instances.
+            _TRANSFORMS[constraint] = transform_class(constraint)
+        elif issubclass(constraint, constraints.Constraint):
+            # Register Constraint subclass.
+            _TRANSFORMS[constraint] = transform_class
+        else:
+            raise TypeError('Expected constraint to be either a Constraint subclass or instance, '
+                            'but got {}'.format(constraint))
+        return transform_class
+
+    return decorator
+
+
+class Transform(object):
+    """
+    Each constraint class registers a pseudoinverse pair of transforms
+    `to_unconstrained` and `from_unconstrained`. These allow standard
+    parameters to be transformed to an unconstrained space for optimization and
+    transformed back after optimization. Note that these are not necessarily
+    inverse pairs since the unconstrained space may have extra dimensions that
+    are projected out; only the one-sided inverse equation is guaranteed::
+
+        x == c.to_constrained(c.to_unconstrained(x))
+
+    """
+    def __init__(self, constraint):
+        self.constraint = constraint
+
+    def to_unconstrained(self, x):
+        """
+        Transform from constrained coordinates to unconstrained coordinates.
+        """
+        raise NotImplementedError
+
+    def to_constrained(self, u):
+        """
+        Transform from unconstrained coordinates to constrained coordinates.
+        """
+        raise NotImplementedError
+
+
+@register_transform(constraints.real)
+class IdentityTransform(Transform):
+    """
+    Identity transform for arbitrary real-valued data.
+    """
+    def to_unconstrained(self, x):
+        return x
+
+    def to_constrained(self, u):
+        return u
+
+
+@register_transform(constraints.positive)
+class LogExpTransform(Transform):
+    """
+    Transform from the positive reals and back via `log()` and `exp()`.
+    """
+    def to_unconstrained(self, x):
+        return torch.log(x)
+
+    def to_constrained(self, u):
+        return torch.exp(u)
+
+
+@register_transform(constraints.greater_than)
+class ShiftLogExpTransform(Transform):
+    """
+    Transform from lower-bounded reals and back via `+`, `log()`, and `exp()`.
+    """
+    def to_unconstrained(self, x):
+        return torch.log(x - self.constraint.lower_bound)
+
+    def to_constrained(self, u):
+        return torch.exp(u) + self.constraint.lower_bound
+
+
+@register_transform(constraints.interval)
+class SigmoidLogitTransform(Transform):
+    """
+    Transform from an arbitrary interval and back via an affine transform and
+    the `logit()` and `sigmoid()` functions.
+    """
+    def to_unconstrained(self, x):
+        c = self.constraint
+        unit = (x - c.lower_bound) / (c.upper_bound - c.lower_bound)
+        return torch.log(unit / (1 - unit))
+
+    def to_constrained(self, u):
+        c = self.constraint
+        unit = torch.sigmoid(u)
+        return c.lower_bound + unit * (c.upper_bound - c.lower_bound)
+
+
+@register_transform(constraints.simplex)
+class LogSoftmaxTransform(Transform):
+    """
+    Transform from the unit simplex and back via `log()` and `softmax()`.
+    """
+    def to_unconstrained(self, x):
+        return torch.log(x)
+
+    def to_constrained(self, u):
+        if isinstance(u, Variable):
+            return softmax(u, dim=-1)
+        return softmax(Variable(u), dim=-1).data
+
+
+@register_transform(constraints.lower_triangular)
+class LowerTriangularTransform(Transform):
+    """
+    Transform from lower-triangular square matrices of size `(n,n)` to
+    contiguous vectors of size `m = n*(n+1)/2`. Dimensions left of the
+    rightmost shape `(n,n)` or `(m,)` are preserved.
+    """
+    def _mask(self, x):
+        mask = torch.tril(x.new([1]).byte().expand(x.shape[-2:]))
+        if x.dim() > 2:
+            mask = mask.view((1,) * (x.dim() - 2) + mask.shape).expand_as(x)
+        return mask
+
+    def to_unconstrained(self, x):
+        n = x.size(-1)
+        m = n * (n + 1) // 2
+        return x[self._mask(x)].view(x.shape[-2:] + (m,))
+
+    def to_constrained(self, u):
+        n = int(round(((8 * u.size(-1) + 1)**0.5 + 1) / 2))
+        x = u.new(n).zero_()
+        x[self._mask(x)] = u
+        return x

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -1,3 +1,23 @@
+r"""
+The :mod:`torch.distributions.transforms` module provides a way to generically
+transform from a constrained parameter space to an unconstrained space and
+back. This is useful for optimizing :class:`~torch.distributions.Distribution`
+parameters.
+
+Each :class:`~torch.distributions.Distribution` object registers
+:class:`~torch.distributions.constraints.Constraint` objects for each of its
+parameters. The :meth:`transform` method inputs a constraint and outputs a
+:class:`Transform` object that can transform to and from an unconstrained
+space.
+
+To extend :meth:`transform` with new user-defined constraints and transforms,
+
+1.  define a new :class:`~torch.distributions.constraints.Constraint` subclass
+    or singleton instance, then
+2.  define a new :class:`Transform` subclass and register it with the
+    :meth:`register_transform` decorator.
+"""
+
 from __future__ import division
 
 import torch

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -176,10 +176,10 @@ class LowerTriangularTransform(Transform):
     def to_unconstrained(self, x):
         n = x.size(-1)
         m = n * (n + 1) // 2
-        return x[self._mask(x)].view(x.shape[-2:] + (m,))
+        return x[self._mask(x)].view(x.shape[:-2] + (m,))
 
     def to_constrained(self, u):
-        n = int(round(((8 * u.size(-1) + 1)**0.5 + 1) / 2))
-        x = u.new(n).zero_()
+        n = int(round(((8 * u.size(-1) + 1)**0.5 - 1) / 2))
+        x = u.new(u.shape[:-1] + (n, n)).zero_()
         x[self._mask(x)] = u
         return x

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -74,7 +74,7 @@ class Transform(object):
     inverse pairs since the unconstrained space may have extra dimensions that
     are projected out; only the one-sided inverse equation is guaranteed::
 
-        x == c.to_constrained(c.to_unconstrained(x))
+        x == t.to_constrained(t.to_unconstrained(x))
 
     """
     def __init__(self, constraint):


### PR DESCRIPTION
This PR registers pseudoinverse pairs (`.to_unconstrained()`, `.to_constrained()`) that are used to transform top-level distribution parameters during optimization. These functions may map between spaces of different dimensionality (e.g. for `simplex`) and therefore are not bijections.

This PR does not register `Bijector`s for transforming sample results for use in HMC. This more complex task will be addressed in #56 and requires an implementation of `Bijector` classes with `.log_abs_det_jacobian()` methods.

This PR does not transform discrete variables, since they are not amenable to stochastic optimization.

See [Design Doc](https://docs.google.com/document/d/1wnABg0cdyaVMr-Xqz_brHBwnPJuzTeSk3Oqko2HHSfE/edit#heading=h.unemmumtnzfk)
Fixes #55 