### PR TITLE
Add kl_divergence(-,-) registration mechanism

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -90,3 +90,9 @@ Probability distributions - torch.distributions
 
 .. autoclass:: Uniform
     :members:
+
+:hidden:`KL Divergence`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automethod:: torch.distributions.kl.kl_divergence
+.. automethod:: torch.distributions.kl.register_kl

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -32,10 +32,10 @@ from common import TestCase, run_tests, set_rng_seed
 from torch.autograd import Variable, gradcheck
 from torch.distributions import (Bernoulli, Beta, Categorical, Cauchy, Chi2,
                                  Dirichlet, Exponential, Gamma, Laplace,
-                                 Normal, OneHotCategorical, Pareto, Uniform)
+                                 Normal, OneHotCategorical, Pareto, Uniform,
+                                 kl_divergence)
 from torch.distributions.constraints import Constraint, is_dependent
 from torch.distributions.utils import _get_clamping_buffer
-
 
 TEST_NUMPY = True
 try:
@@ -1067,6 +1067,30 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(laplace.sample((3, 2)).size(), torch.Size((3, 2, 2)))
         self.assertEqual(laplace.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, laplace.log_prob, self.tensor_sample_2)
+
+
+class TestKL(TestCase):
+    def setUp(self):
+        self.examples = [
+            (Gamma(1, 2), Gamma(3, 4)),
+            (Chi2(2), Chi2(3)),
+            (Gamma(1, 2), Chi2(3)),
+            (Chi2(2), Gamma(3, 4)),
+        ]
+
+    def test_kl_empirical(self):
+        set_rng_seed(0)  # see Note [Randomized statistical tests]
+        for p, q in self.examples:
+            x = p.sample(sample_shape=(10000,))
+            expected = (p.log_prob(x) - q.log_prob(x)).mean()
+            actual = kl_divergence(p, q)
+            message = 'Incorrect KL({}, {}) shape. expected (1,), actual {}'.format(
+                type(p).__name__, type(q).__name__, actual.shape)
+            self.assertEqual(actual.shape, torch.Size((1,)), message=message)
+            actual = actual[0]
+            message = 'Incorrect KL({}, {}). expected {}, actual {}'.format(
+                type(p).__name__, type(q).__name__, expected, actual)
+            self.assertEqual(expected, actual, prec=0.1, message=message)
 
 
 class TestConstraints(TestCase):

--- a/torch/distributions/__init__.py
+++ b/torch/distributions/__init__.py
@@ -34,11 +34,12 @@ from .bernoulli import Bernoulli
 from .beta import Beta
 from .categorical import Categorical
 from .cauchy import Cauchy
+from .chi2 import Chi2
 from .dirichlet import Dirichlet
 from .distribution import Distribution
 from .exponential import Exponential
 from .gamma import Gamma
-from .chi2 import Chi2
+from .kl import kl_divergence, register_kl
 from .laplace import Laplace
 from .normal import Normal
 from .one_hot_categorical import OneHotCategorical
@@ -60,4 +61,6 @@ __all__ = [
     'OneHotCategorical',
     'Pareto',
     'Uniform',
+    'kl_divergence',
+    'register_kl',
 ]

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -5,6 +5,7 @@ from torch.autograd import Function, Variable
 from torch.autograd.function import once_differentiable
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
+from torch.distributions.kl import register_kl
 from torch.distributions.utils import broadcast_all
 
 
@@ -54,3 +55,12 @@ class Gamma(Distribution):
     def entropy(self):
         return (self.alpha - torch.log(self.beta) + torch.lgamma(self.alpha) +
                 (1.0 - self.alpha) * torch.digamma(self.alpha))
+
+
+@register_kl(Gamma, Gamma)
+def _kl_gamma_gamma(p, q):
+    # Adapted from https://stats.stackexchange.com/questions/11646
+    def f(a, b, c, d):
+        return -d * a / c + b * a.log() - torch.lgamma(b) + (b - 1) * torch.digamma(d) + (1 - b) * c.log()
+
+    return f(p.beta, p.alpha, p.beta, p.alpha) - f(q.beta, q.alpha, p.beta, p.alpha)

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -1,0 +1,64 @@
+from collections import OrderedDict
+
+import torch
+from torch.distributions.distribution import Distribution
+
+KL_REGISTRY = OrderedDict()
+
+
+def register_kl(type_p, type_q):
+    """
+    Decorator to register a pairwise function with :meth:`kl_divergence`.
+    Usage::
+
+        @register_kl(Normal, Normal)
+        def kl_normal_normal(p, q):
+            # insert implementation here
+
+    Args:
+        type_p (type): A distribution subclass.
+        type_q (type): A distribution subclass.
+    """
+    if not isinstance(type_p, type) and issubclass(type_p, Distribution):
+        raise TypeError('Expected type_p to be a Distribution subclass but got {}'.format(type_p))
+    if not isinstance(type_q, type) and issubclass(type_q, Distribution):
+        raise TypeError('Expected type_q to be a Distribution subclass but got {}'.format(type_q))
+    p_registry = KL_REGISTRY.setdefault(type_p, OrderedDict())
+
+    def decorator(fun):
+        p_registry[type_q] = fun
+        return fun
+
+    return decorator
+
+
+def _dispatch_kl(type_p, type_q):
+    # Look for an exact match.
+    try:
+        return KL_REGISTRY[type_p][type_q]
+    except KeyError:
+        pass
+    # Look for the first approximate match.
+    for super_p, p_registry in KL_REGISTRY.items():
+        if issubclass(type_p, super_p):
+            try:
+                return p_registry[type_q]
+            except KeyError:
+                for super_q, fun in p_registry.items():
+                    if issubclass(type_q, super_q):
+                        return fun
+    raise NotImplementedError
+
+
+def kl_divergence(p, q):
+    """
+    Compute Kullback-Leibler divergence `KL(p || q)` between two distributions.
+
+    Args:
+        p (Distribution): A distribution object.
+        q (Distribution): A distribution object.
+
+    Returns:
+        (Variable or Tensor): A batch of KL distributions of shape `batch_shape`.
+    """
+    return _dispatch_kl(type(p), type(q))(p, q)

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -66,6 +66,11 @@ def kl_divergence(p, q):
     try:
         fun = _KL_DISPATCH_TABLE[type(p), type(q)]
     except KeyError:
-        fun = _dispatch_kl(type(p), type(q))
+        try:
+            fun = _dispatch_kl(type(p), type(q))
+        except NotImplementedError:
+            fun = NotImplemented
         _KL_DISPATCH_TABLE[type(p), type(q)] = fun
+    if fun is NotImplemented:
+        raise NotImplementedError
     return fun(p, q)

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -16,9 +16,15 @@ def register_kl(type_p, type_q):
         def kl_normal_normal(p, q):
             # insert implementation here
 
+    Lookup order is:
+
+    1.  First look for an exact match.
+    2.  Then find the first pair of registered superclasses, in order that
+        functions were registered.
+
     Args:
-        type_p (type): A distribution subclass.
-        type_q (type): A distribution subclass.
+        type_p (type): A subclass of :class:`~torch.distributions.Distribution`.
+        type_q (type): A subclass of :class:`~torch.distributions.Distribution`.
     """
     if not isinstance(type_p, type) and issubclass(type_p, Distribution):
         raise TypeError('Expected type_p to be a Distribution subclass but got {}'.format(type_p))
@@ -53,15 +59,23 @@ def _dispatch_kl(type_p, type_q):
 
 
 def kl_divergence(p, q):
-    """
-    Compute Kullback-Leibler divergence `KL(p || q)` between two distributions.
+    r"""
+    Compute Kullback-Leibler divergence :math:`KL(p \| q)` between two distributions.
+
+    .. math::
+
+        KL(p \| q) = \int p(x) \log\frac {p(x)} {q(x)} \,dx
 
     Args:
-        p (Distribution): A distribution object.
-        q (Distribution): A distribution object.
+        p (Distrubution): A :class:`~torch.distributions.Distribution` object.
+        q (Distrubution): A :class:`~torch.distributions.Distribution` object.
 
     Returns:
-        (Variable or Tensor): A batch of KL distributions of shape `batch_shape`.
+        (Variable or Tensor): A batch of KL divergences of shape `batch_shape`.
+
+    Raises:
+        NotImplementedError: If the distribution types have not been registered via
+            :meth:`register_kl`.
     """
     try:
         fun = _KL_DISPATCH_TABLE[type(p), type(q)]


### PR DESCRIPTION
Addresses #37 

This adds a generic function `kl_divergence(-,-)` and a registration decorator
```py
@register_kl(Normal, Normal)
def _kl_normal_normal(p, q):
    ...
```
such that `kl_divergence(Normal(0, 1), Normal(0, 2))` will call `_kl_normal_normal()` under the hood.

The implementation has worst-case lookup time linear in the number of registered distribution classes (including failed lookup for `NotImplementedError`), and has amortized constant time. It is important to keep this cheap so that generic inference algorithms can
```py
try:
    kl = kl_divergence(p, q):
except NotImplementedError:
    ...use a more expensive method...
```
  
  