### PR TITLE
add half cauchy distribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -73,6 +73,12 @@ Probability distributions - torch.distributions
 .. autoclass:: Gumbel
     :members:
 
+:hidden:`HalfCauchy`
+~~~~~~~~~~~~~~~~
+
+.. autoclass:: HalfCauchy
+    :members:
+
 :hidden:`Laplace`
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/torch/distributions/__init__.py
+++ b/torch/distributions/__init__.py
@@ -41,6 +41,7 @@ from .distribution import Distribution
 from .exponential import Exponential
 from .gamma import Gamma
 from .gumbel import Gumbel
+from .half_cauchy import HalfCauchy
 from .kl import kl_divergence, register_kl
 from .laplace import Laplace
 from .multinomial import Multinomial
@@ -62,6 +63,7 @@ __all__ = [
     'Exponential',
     'Gamma',
     'Gumbel',
+    'HalfCauchy',
     'Laplace',
     'Multinomial',
     'Normal',

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -43,7 +43,7 @@ class Dirichlet(Distribution):
     Example::
 
         >>> m = Dirichlet(torch.Tensor([0.5, 0.5]))
-        >>> m.sample()  # Dirichlet distributed with concentrarion concentration
+        >>> m.sample()  # Dirichlet distributed with concentration concentration
          0.1046
          0.8954
         [torch.FloatTensor of size 2]

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -1,0 +1,55 @@
+import math
+from numbers import Number
+
+import torch
+from torch.distributions import constraints
+from torch.distributions.distribution import Distribution
+from torch.distributions import Cauchy
+from torch.distributions.utils import broadcast_all
+
+
+class HalfCauchy(Distribution):
+    r"""
+    Half-Cauchy distribution.
+
+    This is a continuous distribution with lower-bounded domain (`x > mu`).
+    See also the `Cauchy` distribution.
+
+    Example::
+
+        >>> m = HalfCauchy(torch.Tensor([0.0]), torch.Tensor([1.0]))
+        >>> m.sample()  # sample from a Cauchy distribution with loc=0 and scale=1
+        >>> m.sample()  # sample from HalfCauchy distributed with loc=0 and scale=1
+         0.3141
+        [torch.FloatTensor of size 1]
+
+    Args:
+        loc (float or Tensor or Variable): lower bound of the distribution.
+        scale (float or Tensor or Variable): half width at half maximum.
+    """
+
+    params = {'loc': constraints.real, 'scale': constraints.positive}
+    support = constraints.positive
+    has_rsample = True
+
+    def __init__(self, loc, scale):
+        self.loc, self.scale = broadcast_all(loc, scale)
+        self._cauchy = Cauchy(loc, scale)
+        if isinstance(loc, Number) and isinstance(scale, Number):
+            batch_shape = torch.Size()
+        else:
+            batch_shape = self.loc.size()
+        super(HalfCauchy, self).__init__(batch_shape)
+
+    def rsample(self, sample_shape=torch.Size()):
+        sample = self._cauchy.rsample(sample_shape)
+        return sample.abs()
+
+    def log_prob(self, value):
+        self._validate_log_prob_arg(value)
+        x_0 = torch.pow((value - self.loc) / self.scale, 2)
+        px = 2 / (math.pi * self.scale * (1 + x_0))
+        return torch.log(px)
+
+    def entropy(self):
+        return math.log(2 * math.pi) + self.scale.log()


### PR DESCRIPTION
not finalized. i used some of the previous distribution PRs as a reference

Implementation:
i reused the cauchy sampler and enforced positivity. the abs() is added to the computation graph, since the whole sampler is differentiable, but im not sure if this is correct. if the transformation happens in place (thereby omitting it from the graph), then the scale gradients will match the signs of the underlying cauchy sample, otherwise the location gradients will.

Tests:
tests are reused from Cauchy sans gradient tests