### PR TITLE
Correctly handle event_dim in Transforms

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -23,6 +23,7 @@ change. This file contains two types of randomized tests:
 """
 
 import math
+import numbers
 import unittest
 from collections import namedtuple
 from itertools import product
@@ -232,6 +233,24 @@ EXAMPLES = [
         {
             'rate': 0.2,
         }
+    ]),
+    Example(TransformedDistribution, [
+        {
+            'base_distribution': Normal(Variable(torch.randn(2, 3), requires_grad=True),
+                                        Variable(torch.randn(2, 3), requires_grad=True)),
+            'transforms': [],
+        },
+        {
+            'base_distribution': Normal(Variable(torch.randn(2, 3), requires_grad=True),
+                                        Variable(torch.randn(2, 3), requires_grad=True)),
+            'transforms': ExpTransform(),
+        },
+        {
+            'base_distribution': Normal(Variable(torch.randn(2, 3), requires_grad=True),
+                                        Variable(torch.randn(2, 3), requires_grad=True)),
+            'transforms': [AffineTransform(Variable(torch.randn(1)), Variable(torch.randn(1))),
+                           ExpTransform()],
+        },
     ]),
     Example(Uniform, [
         {
@@ -1982,7 +2001,7 @@ class TestConstraints(TestCase):
             for i, param in enumerate(params):
                 dist = Dist(**param)
                 for name, value in param.items():
-                    if not (torch.is_tensor(value) or isinstance(value, Variable)):
+                    if isinstance(value, numbers.Number):
                         value = torch.Tensor([value])
                     if Dist in (Categorical, OneHotCategorical, Multinomial) and name == 'probs':
                         # These distributions accept positive probs, but elsewhere we

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -7,11 +7,11 @@ from torch.distributions.distribution import Distribution
 class TransformedDistribution(Distribution):
     r"""
     Extension of the Distribution class, which applies a sequence of Transforms
-    to a base distribution.  Let f be the composition of transforms applied,
+    to a base distribution.  Let f be the composition of transforms applied::
 
         X ~ BaseDistribution
         Y = f(X) ~ TransformedDistribution(BaseDistribution, f)
-        log p(Y) = log p(X) + log det (dX/dY)
+        log p(Y) = log p(X) + log |det (dX/dY)|
     """
     def __init__(self, base_distribution, transforms):
         self.base_dist = base_distribution

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -220,7 +220,7 @@ class ComposeTransform(Transform):
 
     @lazy_property
     def event_dim(self):
-        return max([0] + [p.event_dim for p in self.parts])
+        return max(p.event_dim for p in self.parts) if self.parts else 0
 
     @property
     def inv(self):


### PR DESCRIPTION
This adds an `.event_dim` attribute to all `Transform`s and correctly handles event shape in `TransformedDistribution.log_prob()`. Cases that we need to handle are:
- When `TransformedDistribution.base_dist` has a larger `event_dim` then its transforms, we need to sum out some of the rightmost dimensions in the `transform.log_abs_det_jacobian()` results, otherwise there will be a shape error.
- When `TransformedDistribution.base_dist` has a smaller `event_dim` than its transforms (e.g. when implementing `MultivariateNormal` as an `AffineOperatorTransform` of univariate `Normal`), we need to sum out the rightmost dimensions of `base_dist.log_prob()`.
- When transforms have differing `event_dim`, we need to sum out all but the largest dim.

This PR also includes fixes to `ComposeTransform.event_dim` and `TransformedDistribution.event_shape`.

This PR was the result of issues that came up in @rachtsingh's #113 and in @fritzo's refactoring of `InverseAutoregressiveFlow` in Pyro.

- [x] add tests