### PR TITLE
Ensure .sample() is detached and .rsample() requires grad

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -364,6 +364,18 @@ class TestDistributions(TestCase):
             actual = dist(param).enumerate_support()
             self.assertEqual(actual, expected)
 
+    def test_sample_detached(self):
+        for Dist, params in EXAMPLES:
+            for i, param in enumerate(params):
+                variable_params = [p for p in param.values() if getattr(p, 'requires_grad', False)]
+                if not variable_params:
+                    continue
+                dist = Dist(**param)
+                sample = dist.sample()
+                self.assertFalse(sample.requires_grad,
+                                 msg='{} example {}/{}, .sample() is not detached'.format(
+                                     Dist.__name__, i + 1, len(params)))
+
     def test_enumerate_support_type(self):
         for Dist, params in EXAMPLES:
             for i, param in enumerate(params):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -376,6 +376,20 @@ class TestDistributions(TestCase):
                                  msg='{} example {}/{}, .sample() is not detached'.format(
                                      Dist.__name__, i + 1, len(params)))
 
+    def test_rsample_requires_grad(self):
+        for Dist, params in EXAMPLES:
+            for i, param in enumerate(params):
+                variable_params = [p for p in param.values() if getattr(p, 'requires_grad', False)]
+                if not variable_params:
+                    continue
+                dist = Dist(**param)
+                if not dist.has_rsample:
+                    continue
+                sample = dist.rsample()
+                self.assertTrue(sample.requires_grad,
+                                msg='{} example {}/{}, .rsample() does not require grad'.format(
+                                    Dist.__name__, i + 1, len(params)))
+
     def test_enumerate_support_type(self):
         for Dist, params in EXAMPLES:
             for i, param in enumerate(params):

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -72,7 +72,7 @@ class Bernoulli(ExponentialFamily):
 
     def sample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
-        return torch.bernoulli(self.probs.expand(shape))
+        return torch.bernoulli(self.probs.expand(shape)).detach()
 
     def log_prob(self, value):
         self._validate_log_prob_arg(value)

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -72,7 +72,8 @@ class Bernoulli(ExponentialFamily):
 
     def sample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
-        return torch.bernoulli(self.probs.expand(shape)).detach()
+        x = torch.bernoulli(self.probs.expand(shape))
+        return x.detach() if hasattr(x, 'detach') else x
 
     def log_prob(self, value):
         self._validate_log_prob_arg(value)

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -83,7 +83,7 @@ class Binomial(Distribution):
 
     def sample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape) + (self.total_count,)
-        return torch.bernoulli(self.probs.unsqueeze(-1).expand(shape)).sum(dim=-1)
+        return torch.bernoulli(self.probs.unsqueeze(-1).expand(shape)).sum(dim=-1).detach()
 
     def log_prob(self, value):
         self._validate_log_prob_arg(value)

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -83,7 +83,8 @@ class Binomial(Distribution):
 
     def sample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape) + (self.total_count,)
-        return torch.bernoulli(self.probs.unsqueeze(-1).expand(shape)).sum(dim=-1).detach()
+        x = torch.bernoulli(self.probs.unsqueeze(-1).expand(shape)).sum(dim=-1)
+        return x.detach() if hasattr(x, 'detach') else x
 
     def log_prob(self, value):
         self._validate_log_prob_arg(value)

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -64,7 +64,7 @@ class Geometric(Distribution):
     def sample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
         u = self.probs.new(shape).uniform_(_finfo(self.probs).tiny, 1)
-        return (u.log() / (-self.probs).log1p()).floor()
+        return (u.log() / (-self.probs).log1p()).floor().detach()
 
     def log_prob(self, value):
         self._validate_log_prob_arg(value)

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -64,7 +64,8 @@ class Geometric(Distribution):
     def sample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
         u = self.probs.new(shape).uniform_(_finfo(self.probs).tiny, 1)
-        return (u.log() / (-self.probs).log1p()).floor().detach()
+        x = (u.log() / (-self.probs).log1p()).floor()
+        return x.detach() if hasattr(x, 'detach') else x
 
     def log_prob(self, value):
         self._validate_log_prob_arg(value)

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -51,7 +51,7 @@ class Normal(ExponentialFamily):
 
     def sample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
-        return torch.normal(self.loc.expand(shape), self.scale.expand(shape))
+        return torch.normal(self.loc.expand(shape), self.scale.expand(shape)).detach()
 
     def rsample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -51,7 +51,8 @@ class Normal(ExponentialFamily):
 
     def sample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
-        return torch.normal(self.loc.expand(shape), self.scale.expand(shape)).detach()
+        x = torch.normal(self.loc.expand(shape), self.scale.expand(shape))
+        return x.detach() if hasattr(x, 'detach') else x
 
     def rsample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -51,7 +51,8 @@ class Poisson(ExponentialFamily):
 
     def sample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
-        return _poisson(self.rate.expand(shape)).detach()
+        x = _poisson(self.rate.expand(shape))
+        return x.detach() if hasattr(x, 'detach') else x
 
     def log_prob(self, value):
         self._validate_log_prob_arg(value)

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -51,7 +51,7 @@ class Poisson(ExponentialFamily):
 
     def sample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
-        return _poisson(self.rate.expand(shape))
+        return _poisson(self.rate.expand(shape)).detach()
 
     def log_prob(self, value):
         self._validate_log_prob_arg(value)

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -55,7 +55,7 @@ class TransformedDistribution(Distribution):
         x = self.base_dist.sample(sample_shape)
         for transform in self.transforms:
             x = transform(x)
-        return x
+        return x.detach() if hasattr(x, 'detach') else x
 
     def rsample(self, sample_shape=torch.Size()):
         """


### PR DESCRIPTION
This fixes a bug in `TransformedDistribution` whereby `.sample()` was accidentally reparameterized. It also fixes a couple other minor `.sample()` bugs and adds to tests to distinguish the behavior of `.sample()` and `.rsample()`.