### PR TITLE
Update torch.distribution docs [WIP]

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -7,6 +7,7 @@ Probability distributions - torch.distributions
 .. automodule:: torch.distributions
 .. currentmodule:: torch.distributions
 
+
 :hidden:`Distribution`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -145,7 +146,7 @@ Probability distributions - torch.distributions
 .. autoclass:: Uniform
     :members:
 
-`KL Divergence`
+KL Divergence
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: torch.distributions.kl
@@ -154,21 +155,21 @@ Probability distributions - torch.distributions
 .. autofunction:: kl_divergence
 .. autofunction:: register_kl
 
-`Transforms`
+Transforms
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: torch.distributions.transforms
     :members:
     :member-order: bysource
 
-`Constraints`
+Constraints
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: torch.distributions.constraints
     :members:
     :member-order: bysource
 
-`Constraint Registry`
+Constraint Registry
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: torch.distributions.constraint_registry

--- a/torch/distributions/__init__.py
+++ b/torch/distributions/__init__.py
@@ -1,19 +1,41 @@
 r"""
-The ``distributions`` package contains parameterizable probability distributions
-and sampling functions.
+The ``torch.distributions`` package contains parameterizable probability distributions
+and sampling functions, as well as other useful statistical methods.
 
-Policy gradient methods can be implemented using the
-:meth:`~torch.distributions.Distribution.log_prob` method, when the probability
-density function is differentiable with respect to its parameters. A basic
-method is the REINFORCE rule:
+Basics
+------
+
+A distribution instance is constructed using parameters of shape ``batch_shape + param_shape``,
+and can be sampled from using the ``sample`` method, which returns
+a ``torch.Tensor`` or ``Variable`` of shape ``sample_shape + batch_shape + event_shape``.
+
+ - Batches over ``sample_shape`` are *independently, identically distributed*
+ - Batches over ``batch_shape`` are *independent*, but differently distributed, depending on params
+ - Batches over ``event_shape`` are generally dependent and correlated
+
+Distributions parameterized by ``torch.Tensor`` give ``torch.Tensor`` samples, and those by ``Variable``
+give ``Variable`` samples. *However*, backpropagation through sampling is not immediate. Consider a
+parameterized distribution :math:`q(x; \lambda)` - sampling and forward propagating through some loss function
+:math:`f(x)` is equivalent to estimating the expectation :math:`\mathbb{E}_{x \sim q(x; \lambda)}[f(x)]`. In
+general, there are two ways to compute the gradient of this quantity with respect to :math:`\lambda`:
+
+1. A basic technique is REINFORCE or the score function method which can be implemented using the
+:meth:`~torch.distributions.Distribution.log_prob` method, when the probability density function is
+differentiable with respect to its parameters:
 
 .. math::
+    \nabla_\lambda \mathbb{E}_{x \sim q(x; \lambda)}[f(x)] =
+        \mathbb{E}_{x \sim q}[f(x) \cdot \nabla_\lambda \log q(x; \lambda)]
 
+Letting :math:`x` be the action taken under a policy and :math:`f` be the corresponding reward gives a way
+to implement policy gradient methods.
+
+.. math::
     \Delta\theta  = \alpha r \frac{\partial\log p(a|\pi^\theta(s))}{\partial\theta}
 
-where :math:`\theta` are the parameters, :math:`\alpha` is the learning rate,
-:math:`r` is the reward and :math:`p(a|\pi^\theta(s))` is the probability of
-taking action :math:`a` in state :math:`s` given policy :math:`\pi^\theta`.
+where :math:`\theta` are the parameters, :math:`\alpha` is the learning rate, :math:`r` is the reward
+and :math:`p(a|\pi^\theta(s))` is the probability of taking action :math:`a` in state :math:`s`
+given policy :math:`\pi^\theta`.
 
 In practice we would sample an action from the output of a network, apply this
 action in an environment, and then use ``log_prob`` to construct an equivalent
@@ -29,20 +51,31 @@ policy, the code for implementing REINFORCE would be as follows::
     loss = -m.log_prob(action) * reward
     loss.backward()
 
-Another way to implement these stochastic/policy gradients would be to use the
-reparameterization trick from :meth:`~torch.distributions.Distribution.rsample`
-method, where the parameterized random variable can be defined as a parameterized
-deterministic function of a parameter-free random variable. The reparameterized sample
-is required to be differentiable. The code for implementing the pathwise estimation would
-be as follows::
+2. Another way to implement these stochastic/policy gradients would be to use the reparameterization
+trick via the :meth:`~torch.distributions.Distribution.rsample` method, where the random variable
+can be defined as a parameterized deterministic function of a parameter-free random variable.
+Reparameterized samples are differentiable with respect to the parameters of their distribution, and
+are limited to distributions which have the ``rsample`` method. Code for implementing the pathwise
+gradient estimate would be as follows::
 
     params = policy_network(state)
     m = Normal(*params)
-    # any distribution with .has_rsample == True could work based on the application
+    # any distribution with .has_rsample == True can work
     action = m.rsample()
     next_state, reward = env.step(action)  # Assume that reward is differentiable
     loss = -reward
     loss.backward()
+
+Advanced Features
+-----------------
+
+The ``torch.distributions`` package also implements KL divergences between many common distributions, their
+entropies, and methods for transforming distributions. For example::
+
+    a = Normal(loc=0, scale=1)
+    b = Normal(loc=2, scale=1)
+    KL = kl_divergence(a, b)
+
 """
 
 from .bernoulli import Bernoulli

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -128,11 +128,11 @@ def _x_log_x(tensor):
 
 def kl_divergence(p, q):
     r"""
-    Compute Kullback-Leibler divergence :math:`KL(p \| q)` between two distributions.
+    Compute Kullback-Leibler divergence :math:`\operatorname{KL}(p \| q)` between two distributions.
 
     .. math::
 
-        KL(p \| q) = \int p(x) \log\frac {p(x)} {q(x)} \,dx
+        \operatorname{KL}(p \| q) = \int p(x) \log\frac {p(x)} {q(x)} \,dx
 
     Args:
         p (Distribution): A :class:`~torch.distributions.Distribution` object.


### PR DESCRIPTION
This PR:

- adds a description of sample shapes and parameter shapes to the `torch.distributions` page, and also adds a small note about KL divergences (please feel free to add more).
- cleans up a few headers for consistency, and tweaks LaTeX a little.

Feel free to add commits or request changes - I'm happy to edit to make these docs high quality. You can preview the docs version committed here via [this link](http://52.170.212.152/distributions.html).

- [ ] Fix `ExponentialFamily` (can someone merge `pytorch/pytorch` master into `probtorch/master`?)
- [ ] Add docs sections for `RelaxedOneHotCategorical` and `RelaxedBernoulli`