### PR TITLE
Implement a generic .detached_log_prob() method

### DIFF
--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -144,6 +144,24 @@ class Distribution(object):
         """
         raise NotImplementedError
 
+    def detached_log_prob(self, value):
+        """
+        Returns the log of the probability density/mass function, detaching
+        gradients with respect to parameters but preserving gradients with
+        respect to `value`.
+
+        Args:
+            value (Tensor):
+        """
+        # This exploits the .expand() method to detach gradients.
+        # This could be replaced with cleaner logic if distributions provided generic
+        # access to parameters.
+        batch_dim = 1 + max(len(self.batch_shape), value.dim() - len(self.event_shape))
+        detached_shape = (1,) * (batch_dim - len(self.batch_shape)) + self.batch_shape
+        with torch.no_grad():
+            detached = self.expand(detached_shape)
+        return detached.log_prob(value)[0]
+
     def cdf(self, value):
         """
         Returns the cumulative density/mass function evaluated at

--- a/torch/distributions/lowrank_multivariate_normal.py
+++ b/torch/distributions/lowrank_multivariate_normal.py
@@ -114,8 +114,8 @@ class LowRankMultivariateNormal(Distribution):
         new.loc = self.loc.expand(loc_shape)
         new.cov_diag = self.cov_diag.expand(loc_shape)
         new.cov_factor = self.cov_factor.expand(loc_shape + self.cov_factor.shape[-1:])
-        new._unbroadcasted_cov_factor = self._unbroadcasted_cov_factor
-        new._unbroadcasted_cov_diag = self._unbroadcasted_cov_diag
+        new._unbroadcasted_cov_factor = self._unbroadcasted_cov_factor[...]
+        new._unbroadcasted_cov_diag = self._unbroadcasted_cov_diag[...]
         new._capacitance_tril = self._capacitance_tril
         super(LowRankMultivariateNormal, new).__init__(batch_shape,
                                                        self.event_shape,

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -156,7 +156,7 @@ class MultivariateNormal(Distribution):
         loc_shape = batch_shape + self.event_shape
         cov_shape = batch_shape + self.event_shape + self.event_shape
         new.loc = self.loc.expand(loc_shape)
-        new._unbroadcasted_scale_tril = self._unbroadcasted_scale_tril
+        new._unbroadcasted_scale_tril = self._unbroadcasted_scale_tril[...]
         if 'covariance_matrix' in self.__dict__:
             new.covariance_matrix = self.covariance_matrix.expand(cov_shape)
         if 'scale_tril' in self.__dict__:


### PR DESCRIPTION
Resolves https://github.com/pytorch/pytorch/issues/25783

This attempts to implement a `.detached_log_prob()` method using the machinery of `.expand()`.

## Tasks
- [ ] add tests